### PR TITLE
Enhance the CheckIfDead package

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -354,7 +354,8 @@ class CheckIfDead {
 		}
 		//Make sure path, query, and fragment are properly encoded, and not overencoded.
 		//This avoids possible 400 Bad Response errors.
-		if( isset( $parts['path'] ) && strlen( $parts['path'] ) > 1 ) $url .= "/".urlencode( substr( urldecode( $parts['path'] ), 1 ) );
+		$url .= "/";
+		if( isset( $parts['path'] ) && strlen( $parts['path'] ) > 1 ) $url .= implode( '/', array_map( "urlencode", explode( '/', substr( urldecode( $parts['path'] ), 1 ) ) ) );
 		if( isset( $parts['query'] ) ) $url .= "?".urlencode( urldecode( $parts['query'] ) );
 		if( isset( $parts['fragment'] ) ) $url .= "#".urlencode( urldecode( $parts['fragment'] ) );
 		return $url;

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -79,13 +79,9 @@ class CheckIfDead {
 			if ( $curl_instances[$id] === false ) {
 				return null;
 			}
-			// In case the protocol is missing, assume it goes to HTTPS
-			if ( is_null( parse_url( $url, PHP_URL_SCHEME ) ) ) {
-				$url = "https:$url";
-				$urls[$id] = $url;
-			}
+
 			// Get appropriate curl options
-			curl_setopt_array( $curl_instances[$id], $this->getCurlOptions( $url, false ) );
+			curl_setopt_array( $curl_instances[$id], $this->getCurlOptions( $this->sanitizeURL( $url ), false ) );
 			// Add the instance handle
 			curl_multi_add_handle( $multicurl_resource, $curl_instances[$id] );
 		}
@@ -111,7 +107,7 @@ class CheckIfDead {
 				'http_code' => $headers['http_code'],
 				'effective_url' => $headers['url'],
 				'curl_error' => $error,
-				'url' => $url
+				'url' => $this->sanitizeURL( $url )
 			];
 			// Remove each of the individual handles
 			curl_multi_remove_handle( $multicurl_resource, $curl_instances[$id] );
@@ -154,7 +150,7 @@ class CheckIfDead {
 				return false;
 			}
 			// Get appropriate curl options
-			curl_setopt_array( $curl_instances[$id], $this->getCurlOptions( $url, true ) );
+			curl_setopt_array( $curl_instances[$id], $this->getCurlOptions( $this->sanitizeURL( $url ), true ) );
 			// Add the instance handle
 			curl_multi_add_handle( $multicurl_resource, $curl_instances[$id] );
 		}
@@ -180,7 +176,7 @@ class CheckIfDead {
 				'http_code' => $headers['http_code'],
 				'effective_url' => $headers['url'],
 				'curl_error' => $error,
-				'url' => $url
+				'url' => $this->sanitizeURL( $url )
 			];
 			// Remove each of the individual handles
 			curl_multi_remove_handle( $multicurl_resource, $curl_instances[$id] );
@@ -268,8 +264,8 @@ class CheckIfDead {
 		}
 		// Check for error messages in redirected URL string
 		if ( strpos( $effectiveUrlClean, '404.htm' ) !== false ||
-			 strpos( $effectiveUrlClean, '/404/' ) !== false ||
-			 stripos( $effectiveUrlClean, 'notfound' ) !== false
+			strpos( $effectiveUrlClean, '/404/' ) !== false ||
+			stripos( $effectiveUrlClean, 'notfound' ) !== false
 		) {
 			return true;
 		}
@@ -324,6 +320,44 @@ class CheckIfDead {
 			$roots[] = implode( '.', array_slice( $parts, -2 ) ) . '/';
 		}
 		return $roots;
+	}
+
+	/**
+	 * Properly encode the URL to ensure the receiving webservice understands the request.
+	 *
+	 * @param $url URL to sanitize
+	 * @return string sanitized URLs.  False on failure.
+	 */
+	protected function sanitizeURL( $url ) {
+		//The domain is easily decoded by the DNS handler, but the path is what's seen by the respective webservice.
+		//We need to decode it because some can't handle encoded characters.
+		$parts = parse_url( $url );
+		$url = "";
+		// In case the protocol is missing, assume it goes to HTTPS
+		if( !isset( $parts['scheme'] ) ) {
+			$url = "https";
+		} else {
+			$url = $parts['scheme'];
+		}
+		//Move on to the domain
+		$url .= "://";
+		//Add username and password if present
+		if( isset( $parts['user'] ) ) {
+			$url .= $parts['user'];
+			if( isset( $parts['pass'] ) ) $url .= ":".$parts['pass'];
+			$url .= "@";
+		}
+		//Add host
+		if( isset( $parts['host'] ) ) {
+			$url .= $parts['host'];
+			if( isset( $parts['port'] ) ) $url .= ":".$parts['port'];
+		}
+		//Make sure path, query, and fragment are properly encoded, and not overencoded.
+		//This avoids possible 400 Bad Response errors.
+		if( isset( $parts['path'] ) && strlen( $parts['path'] ) > 1 ) $url .= "/".urlencode( substr( urldecode( $parts['path'] ), 1 ) );
+		if( isset( $parts['query'] ) ) $url .= "?".urlencode( urldecode( $parts['query'] ) );
+		if( isset( $parts['fragment'] ) ) $url .= "#".urlencode( urldecode( $parts['fragment'] ) );
+		return $url;
 	}
 
 	/**

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -51,7 +51,7 @@ class CheckIfDead {
 	 *     Otherwise returns true (dead) or false (alive).
 	 */
 	public function isLinkDead( $url ) {
-		$deadVal = $this->areLinksDead( array( $url ) );
+		$deadVal = $this->areLinksDead( [$url] );
 		$deadVal = $deadVal[$url];
 		return $deadVal;
 	}
@@ -81,7 +81,10 @@ class CheckIfDead {
 			}
 
 			// Get appropriate curl options
-			curl_setopt_array( $curl_instances[$id], $this->getCurlOptions( $this->sanitizeURL( $url ), false ) );
+			curl_setopt_array(
+				$curl_instances[$id],
+				$this->getCurlOptions( $this->sanitizeURL( $url ), false )
+			);
 			// Add the instance handle
 			curl_multi_add_handle( $multicurl_resource, $curl_instances[$id] );
 		}
@@ -150,7 +153,10 @@ class CheckIfDead {
 				return false;
 			}
 			// Get appropriate curl options
-			curl_setopt_array( $curl_instances[$id], $this->getCurlOptions( $this->sanitizeURL( $url ), true ) );
+			curl_setopt_array(
+				$curl_instances[$id],
+				$this->getCurlOptions( $this->sanitizeURL( $url ), true)
+			);
 			// Add the instance handle
 			curl_multi_add_handle( $multicurl_resource, $curl_instances[$id] );
 		}
@@ -329,35 +335,54 @@ class CheckIfDead {
 	 * @return string sanitized URLs.  False on failure.
 	 */
 	protected function sanitizeURL( $url ) {
-		//The domain is easily decoded by the DNS handler, but the path is what's seen by the respective webservice.
-		//We need to decode it because some can't handle encoded characters.
+		// The domain is easily decoded by the DNS handler,
+		// but the path is what's seen by the respective webservice.
+		// We need to encode it as some
+		// can't handle decoded characters.
 		$parts = parse_url( $url );
 		$url = "";
 		// In case the protocol is missing, assume it goes to HTTPS
-		if( !isset( $parts['scheme'] ) ) {
+		if ( !isset( $parts['scheme'] ) ) {
 			$url = "https";
 		} else {
 			$url = $parts['scheme'];
 		}
-		//Move on to the domain
+		// Move on to the domain
 		$url .= "://";
-		//Add username and password if present
-		if( isset( $parts['user'] ) ) {
+		// Add username and password if present
+		if ( isset( $parts['user'] ) ) {
 			$url .= $parts['user'];
-			if( isset( $parts['pass'] ) ) $url .= ":".$parts['pass'];
+			if (isset($parts['pass'])) {
+				$url .= ":" . $parts['pass'];
+			}
 			$url .= "@";
 		}
-		//Add host
-		if( isset( $parts['host'] ) ) {
+		// Add host
+		if ( isset( $parts['host'] ) ) {
 			$url .= $parts['host'];
-			if( isset( $parts['port'] ) ) $url .= ":".$parts['port'];
+			if (isset($parts['port'])) {
+				$url .= ":" . $parts['port'];
+			}
 		}
-		//Make sure path, query, and fragment are properly encoded, and not overencoded.
-		//This avoids possible 400 Bad Response errors.
+		// Make sure path, query, and fragment are properly encoded, and not overencoded.
+		// This avoids possible 400 Bad Response errors.
 		$url .= "/";
-		if( isset( $parts['path'] ) && strlen( $parts['path'] ) > 1 ) $url .= implode( '/', array_map( "urlencode", explode( '/', substr( urldecode( $parts['path'] ), 1 ) ) ) );
-		if( isset( $parts['query'] ) ) $url .= "?".urlencode( urldecode( $parts['query'] ) );
-		if( isset( $parts['fragment'] ) ) $url .= "#".urlencode( urldecode( $parts['fragment'] ) );
+		if ( isset( $parts['path'] ) && strlen( $parts['path'] ) > 1 ) {
+			$url .= implode( '/',
+				array_map( "urlencode",
+					explode( '/',
+						substr( 
+							urldecode( $parts['path'] ), 1 )
+					)
+				)
+			);
+		}
+		if ( isset( $parts['query'] ) ) {
+			$url .= "?".urlencode( urldecode( $parts['query'] ) );
+		}
+		if ( isset( $parts['fragment'] ) ) {
+			$url .= "#".urlencode( urldecode( $parts['fragment'] ) );
+		}
 		return $url;
 	}
 

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -51,7 +51,7 @@ class CheckIfDead {
 	 *     Otherwise returns true (dead) or false (alive).
 	 */
 	public function isLinkDead( $url ) {
-		$deadVal = $this->areLinksDead ( [$url] );
+		$deadVal = $this->areLinksDead( [ $url ] );
 		$deadVal = $deadVal[$url];
 		return $deadVal;
 	}
@@ -352,7 +352,7 @@ class CheckIfDead {
 		// Add username and password if present
 		if ( isset( $parts['user'] ) ) {
 			$url .= $parts['user'];
-			if ( isset($parts['pass'] ) ) {
+			if ( isset( $parts['pass'] ) ) {
 				$url .= ":" . $parts['pass'];
 			}
 			$url .= "@";
@@ -360,7 +360,7 @@ class CheckIfDead {
 		// Add host
 		if ( isset( $parts['host'] ) ) {
 			$url .= $parts['host'];
-			if ( isset($parts['port'] ) ) {
+			if ( isset( $parts['port'] ) ) {
 				$url .= ":" . $parts['port'];
 			}
 		}
@@ -371,7 +371,7 @@ class CheckIfDead {
 			$url .= implode( '/',
 				array_map( "urlencode",
 					explode( '/',
-						substr(				
+						substr(
 							urldecode( $parts['path'] ), 1 )
 					)
 				)

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -51,25 +51,8 @@ class CheckIfDead {
 	 *     Otherwise returns true (dead) or false (alive).
 	 */
 	public function isLinkDead( $url ) {
-		$ch = curl_init();
-		if ( $ch === false ) {
-			return null;
-		}
-		// In case the protocol is missing, assume it goes to HTTPS
-		if ( is_null( parse_url( $url, PHP_URL_SCHEME ) ) ) {
-			$url = "https:$url";
-		}
-		curl_setopt_array( $ch, $this->getCurlOptions( $url, true ) );
-		curl_exec( $ch );
-		$headers = curl_getinfo( $ch );
-		$error = curl_error( $ch );
-		$curlInfo = [
-			'http_code' => $headers['http_code'],
-			'effective_url' => $headers['url'],
-			'curl_error' => $error,
-			'url' => $url
-		];
-		$deadVal = $this->processCurlResults( $curlInfo, true );
+		$deadVal = $this->areLinksDead( array( $url ) );
+		$deadVal = $deadVal[$url];
 		return $deadVal;
 	}
 

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -51,7 +51,7 @@ class CheckIfDead {
 	 *     Otherwise returns true (dead) or false (alive).
 	 */
 	public function isLinkDead( $url ) {
-		$deadVal = $this->areLinksDead( [$url] );
+		$deadVal = $this->areLinksDead ( [$url] );
 		$deadVal = $deadVal[$url];
 		return $deadVal;
 	}
@@ -155,7 +155,7 @@ class CheckIfDead {
 			// Get appropriate curl options
 			curl_setopt_array(
 				$curl_instances[$id],
-				$this->getCurlOptions( $this->sanitizeURL( $url ), true)
+				$this->getCurlOptions( $this->sanitizeURL( $url ), true )
 			);
 			// Add the instance handle
 			curl_multi_add_handle( $multicurl_resource, $curl_instances[$id] );
@@ -352,7 +352,7 @@ class CheckIfDead {
 		// Add username and password if present
 		if ( isset( $parts['user'] ) ) {
 			$url .= $parts['user'];
-			if (isset($parts['pass'])) {
+			if ( isset($parts['pass'] ) ) {
 				$url .= ":" . $parts['pass'];
 			}
 			$url .= "@";
@@ -360,7 +360,7 @@ class CheckIfDead {
 		// Add host
 		if ( isset( $parts['host'] ) ) {
 			$url .= $parts['host'];
-			if (isset($parts['port'])) {
+			if ( isset($parts['port'] ) ) {
 				$url .= ":" . $parts['port'];
 			}
 		}
@@ -371,7 +371,7 @@ class CheckIfDead {
 			$url .= implode( '/',
 				array_map( "urlencode",
 					explode( '/',
-						substr( 
+						substr(				
 							urldecode( $parts['path'] ), 1 )
 					)
 				)


### PR DESCRIPTION
Simplify the single URL checker by running the multiple URL function, to re-use code.
Sanitize partially decoded or fully decoded URLs that can possibly result in a 400 Bad Response error.